### PR TITLE
[Feat] 전체 예약 조회 API 추가

### DIFF
--- a/src/main/java/com/example/ddingsroom/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/ddingsroom/reservation/controller/ReservationController.java
@@ -68,4 +68,14 @@ public class ReservationController {
                 response.getReservations() != null ? response.getReservations().size() : 0);
         return ResponseEntity.ok(response);
     }
+    @GetMapping("/all-reservation")
+    public ResponseEntity<ReservationResponseDTO> getAllReservations() {
+        logger.info("전체 예약 조회 요청");
+
+        ReservationResponseDTO response = reservationService.getAllReservations();
+
+        logger.info("전체 예약 조회 완료: count={}",
+                response.getReservations() != null ? response.getReservations().size() : 0);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/example/ddingsroom/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/ddingsroom/reservation/service/ReservationService.java
@@ -176,4 +176,27 @@ public class ReservationService {
             return responseDTO;
         }
     }
+    @Transactional(readOnly = true)
+    public ReservationResponseDTO getAllReservations() {
+        try {
+            List<ReservationEntity> reservationEntities = reservationRepository.findAll();
+
+            List<ReservationResponseDTO.ReservationDTO> reservationDTOs = reservationEntities.stream()
+                    .map(ReservationResponseDTO.ReservationDTO::fromEntity)
+                    .collect(Collectors.toList());
+
+            ReservationResponseDTO responseDTO = new ReservationResponseDTO();
+            responseDTO.setMessage("데이터 조회가 성공적으로 진행되었습니다.");
+            responseDTO.setReservations(reservationDTOs);
+
+            return responseDTO;
+        } catch (Exception e) {
+            logger.error("전체 예약 조회 중 오류 발생: {}", e.getMessage(), e);
+            ReservationResponseDTO responseDTO = new ReservationResponseDTO();
+            responseDTO.setMessage("예약 조회 중 오류가 발생했습니다. 나중에 다시 시도해주세요.");
+            responseDTO.setReservations(List.of());
+            return responseDTO;
+        }
+    }
+
 }


### PR DESCRIPTION
# 전체 예약 조회 API 추가

## 기능 소개
- `/api/reservations/all-reservation` 엔드포인트 추가
- 시스템에 저장된 모든 예약 정보를 한 번에 조회할 수 있음

## 구현 내용
- ReservationController에 `getAllReservations()` 메서드 추가

## 포스트맨 테스트 방법
1. 요청 유형: **GET**
2. URL: `http://localhost:8080/api/reservations/all-reservation`
3. 요청 본문: 필요 없음 (GET 요청)
4. 성공 응답:
   ```json
   {
     "message": "데이터 조회가 성공적으로 진행되었습니다.",
     "reservations": [
       {
         "id": 1,
         "userId": 1,
         "roomId": 2,
         "roomName": "스터디룸 A",
         "startTime": "2025-05-15T10:00:00",
         "endTime": "2025-05-15T12:00:00",
         "status": "RESERVED",
         "createdAt": "2025-05-14T15:30:00",
         "updatedAt": "2025-05-14T15:30:00"
       },
       // ... 기타 예약 정보
     ]
   }
   ```
