### PR TITLE
[Feat] 유저 이름 변경 api & 인증코드 유효 시간 제한

### DIFF
--- a/src/main/java/com/example/ddingsroom/user/controller/JoinController.java
+++ b/src/main/java/com/example/ddingsroom/user/controller/JoinController.java
@@ -53,4 +53,9 @@ public class JoinController {
     public ResponseEntity<ResponseDTO> deleteUser(@PathVariable String email) {
         return joinService.deleteUser(email);
     }
+
+    @PutMapping("/change-username")
+    public ResponseEntity<ResponseDTO> changeUsername(@RequestBody com.example.ddingsroom.user.dto.ChangeUsernameDTO changeUsernameDTO) {
+        return joinService.changeUsername(changeUsernameDTO);
+    }
 }

--- a/src/main/java/com/example/ddingsroom/user/dto/ChangeUsernameDTO.java
+++ b/src/main/java/com/example/ddingsroom/user/dto/ChangeUsernameDTO.java
@@ -1,0 +1,19 @@
+package com.example.ddingsroom.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ChangeUsernameDTO {
+    private Integer userId;
+    private String newUsername;
+
+    public ChangeUsernameDTO() {}
+
+    public ChangeUsernameDTO(Integer userId, String newUsername) {
+        this.userId = userId;
+        this.newUsername = newUsername;
+    }
+
+}

--- a/src/main/java/com/example/ddingsroom/user/service/JoinService.java
+++ b/src/main/java/com/example/ddingsroom/user/service/JoinService.java
@@ -138,6 +138,16 @@ public class JoinService {
             if (verificationCodeOptional.isPresent()) {
                 VerificationCode verificationCode = verificationCodeOptional.get();
 
+                // 인증코드 만료 시간 체크 (5분 = 300초)
+                LocalDateTime publishedTime = verificationCode.getPublishedDate();
+                LocalDateTime currentTime = LocalDateTime.now();
+                long minutesDifference = java.time.Duration.between(publishedTime, currentTime).toMinutes();
+
+                if (minutesDifference > 5) {
+                    verificationCodeRepository.delete(verificationCode);
+                    return ResponseEntity.badRequest().body(new ResponseDTO("인증코드가 만료되었습니다."));
+                }
+
                 if (verificationCode.getCode().equals(code)) {
                     verificationCodeRepository.delete(verificationCode);
                     return ResponseEntity.ok(new ResponseDTO("이메일 인증이 성공적으로 완료되었습니다."));
@@ -293,6 +303,37 @@ public class JoinService {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new ResponseDTO("회원탈퇴 중 오류가 발생했습니다: " + e.getMessage()));
+        }
+    }
+
+    public ResponseEntity<ResponseDTO> changeUsername(com.example.ddingsroom.user.dto.ChangeUsernameDTO changeUsernameDTO) {
+        try {
+            if (changeUsernameDTO.getUserId() == null) {
+                return ResponseEntity.badRequest().body(new ResponseDTO("사용자 ID를 입력해주세요."));
+            }
+            if (!StringUtils.hasText(changeUsernameDTO.getNewUsername())) {
+                return ResponseEntity.badRequest().body(new ResponseDTO("새 사용자명을 입력해주세요."));
+            }
+
+            Optional<UserEntity> userEntityOptional = userRepository.findById(changeUsernameDTO.getUserId());
+            if (userEntityOptional.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(new ResponseDTO("해당 사용자를 찾을 수 없습니다."));
+            }
+
+            if (userRepository.existsByUsername(changeUsernameDTO.getNewUsername())) {
+                return ResponseEntity.badRequest().body(new ResponseDTO("중복된 이름입니다."));
+            }
+
+            UserEntity user = userEntityOptional.get();
+            user.setUsername(changeUsernameDTO.getNewUsername());
+            userRepository.save(user);
+
+            return ResponseEntity.ok(new ResponseDTO("사용자명이 성공적으로 변경되었습니다."));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseDTO("사용자명 변경 중 오류가 발생했습니다: " + e.getMessage()));
         }
     }
 }


### PR DESCRIPTION
## [Feat] 유저 이름 변경 api & 인증코드 유효 시간 제한

1. 유저 이름 변경 API (PUT /user/change-username)
  - ChangeUsernameDTO 클래스 생성 (userId, newUsername 필드)
  - 중복 사용자명 검증 로직 포함

2. verifyCode 메서드 고도화
  - 인증코드 발행 시간과 현재 시간 비교
  - 5분 초과시 인증코드 삭제 후 "인증코드가 만료되었습니다." 메시지 반환
