### PR TITLE
[Refactoring] Entity ID 타입 통일 및 JPA 관계 매핑 개선

### DIFF
--- a/src/main/java/com/example/ddingsroom/admin/controller/AdminReservationController.java
+++ b/src/main/java/com/example/ddingsroom/admin/controller/AdminReservationController.java
@@ -40,7 +40,7 @@ public class AdminReservationController {
     @Operation(summary = "특정 예약 조회", description = "예약 ID로 특정 예약의 상세 정보를 조회합니다.")
     public ResponseEntity<?> getReservationById(
             @Parameter(description = "예약 ID", required = true)
-            @PathVariable Integer reservationId) {
+            @PathVariable Long reservationId) {
         logger.info("관리자 - 예약 상세 조회 요청: reservationId={}", reservationId);
         return adminReservationService.getReservationById(reservationId);
     }
@@ -49,7 +49,7 @@ public class AdminReservationController {
     @Operation(summary = "예약 강제 취소", description = "관리자 권한으로 특정 예약을 강제 취소합니다.")
     public ResponseEntity<AdminResponseDTO> forceCancelReservation(
             @Parameter(description = "예약 ID", required = true)
-            @PathVariable Integer reservationId) {
+            @PathVariable Long reservationId) {
         logger.info("관리자 - 예약 강제 취소 요청: reservationId={}", reservationId);
         return adminReservationService.forceCancelReservation(reservationId);
     }
@@ -94,7 +94,7 @@ public class AdminReservationController {
     @Operation(summary = "특정 사용자 예약 조회", description = "특정 사용자의 모든 예약을 조회합니다.")
     public ResponseEntity<?> getReservationsByUserId(
             @Parameter(description = "사용자 ID", required = true)
-            @PathVariable Integer userId) {
+            @PathVariable Long userId) {
         logger.info("관리자 - 사용자별 예약 조회 요청: userId={}", userId);
         return adminReservationService.getReservationsByUserId(userId);
     }

--- a/src/main/java/com/example/ddingsroom/admin/controller/AdminRoomController.java
+++ b/src/main/java/com/example/ddingsroom/admin/controller/AdminRoomController.java
@@ -38,7 +38,7 @@ public class AdminRoomController {
     @Operation(summary = "특정 스터디룸 조회", description = "룸 ID로 특정 스터디룸의 상세 정보를 조회합니다.")
     public ResponseEntity<?> getRoomById(
             @Parameter(description = "스터디룸 ID", required = true)
-            @PathVariable Integer roomId) {
+            @PathVariable Long roomId) {
         logger.info("관리자 - 스터디룸 상세 조회 요청: roomId={}", roomId);
         return adminRoomService.getRoomById(roomId);
     }
@@ -54,7 +54,7 @@ public class AdminRoomController {
     @Operation(summary = "스터디룸 정보 수정", description = "기존 스터디룸의 정보를 수정합니다.")
     public ResponseEntity<AdminResponseDTO> updateRoom(
             @Parameter(description = "스터디룸 ID", required = true)
-            @PathVariable Integer roomId,
+            @PathVariable Long roomId,
             @RequestBody AdminRoomRequestDTO roomRequestDTO) {
         logger.info("관리자 - 스터디룸 수정 요청: roomId={}, roomName={}", roomId, roomRequestDTO.getRoomName());
         return adminRoomService.updateRoom(roomId, roomRequestDTO);
@@ -64,7 +64,7 @@ public class AdminRoomController {
     @Operation(summary = "스터디룸 상태 변경", description = "스터디룸의 상태를 변경합니다 (IDLE/OCCUPIED/MAINTENANCE)")
     public ResponseEntity<AdminResponseDTO> updateRoomStatus(
             @Parameter(description = "스터디룸 ID", required = true)
-            @PathVariable Integer roomId,
+            @PathVariable Long roomId,
             @Parameter(description = "변경할 상태 (IDLE/OCCUPIED/MAINTENANCE)", required = true)
             @RequestParam String status) {
         logger.info("관리자 - 스터디룸 상태 변경 요청: roomId={}, status={}", roomId, status);
@@ -75,7 +75,7 @@ public class AdminRoomController {
     @Operation(summary = "스터디룸 삭제", description = "스터디룸을 시스템에서 삭제합니다.")
     public ResponseEntity<AdminResponseDTO> deleteRoom(
             @Parameter(description = "스터디룸 ID", required = true)
-            @PathVariable Integer roomId) {
+            @PathVariable Long roomId) {
         logger.info("관리자 - 스터디룸 삭제 요청: roomId={}", roomId);
         return adminRoomService.deleteRoom(roomId);
     }
@@ -91,7 +91,7 @@ public class AdminRoomController {
     @Operation(summary = "스터디룸별 예약 현황", description = "특정 스터디룸의 예약 현황을 조회합니다.")
     public ResponseEntity<?> getRoomReservations(
             @Parameter(description = "스터디룸 ID", required = true)
-            @PathVariable Integer roomId) {
+            @PathVariable Long roomId) {
         logger.info("관리자 - 스터디룸별 예약 현황 조회 요청: roomId={}", roomId);
         return adminRoomService.getRoomReservations(roomId);
     }

--- a/src/main/java/com/example/ddingsroom/admin/controller/AdminUserController.java
+++ b/src/main/java/com/example/ddingsroom/admin/controller/AdminUserController.java
@@ -37,7 +37,7 @@ public class AdminUserController {
     @Operation(summary = "특정 사용자 조회", description = "사용자 ID로 특정 사용자의 상세 정보를 조회합니다.")
     public ResponseEntity<?> getUserById(
             @Parameter(description = "사용자 ID", required = true)
-            @PathVariable Integer userId) {
+            @PathVariable Long userId) {
         logger.info("관리자 - 사용자 상세 조회 요청: userId={}", userId);
         return adminUserService.getUserById(userId);
     }
@@ -46,7 +46,7 @@ public class AdminUserController {
     @Operation(summary = "사용자 상태 변경", description = "특정 사용자의 상태를 변경합니다 (normal/blocked)")
     public ResponseEntity<AdminResponseDTO> updateUserStatus(
             @Parameter(description = "사용자 ID", required = true)
-            @PathVariable Integer userId,
+            @PathVariable Long userId,
             @Parameter(description = "변경할 상태 (normal/blocked)", required = true)
             @RequestParam String status) {
         logger.info("관리자 - 사용자 상태 변경 요청: userId={}, status={}", userId, status);
@@ -57,7 +57,7 @@ public class AdminUserController {
     @Operation(summary = "사용자 권한 변경", description = "특정 사용자의 권한을 변경합니다 (ROLE_USER/ROLE_ADMIN)")
     public ResponseEntity<AdminResponseDTO> updateUserRole(
             @Parameter(description = "사용자 ID", required = true)
-            @PathVariable Integer userId,
+            @PathVariable Long userId,
             @Parameter(description = "변경할 권한 (ROLE_USER/ROLE_ADMIN)", required = true)
             @RequestParam String role) {
         logger.info("관리자 - 사용자 권한 변경 요청: userId={}, role={}", userId, role);
@@ -68,7 +68,7 @@ public class AdminUserController {
     @Operation(summary = "사용자 삭제", description = "특정 사용자를 시스템에서 삭제합니다.")
     public ResponseEntity<AdminResponseDTO> deleteUser(
             @Parameter(description = "사용자 ID", required = true)
-            @PathVariable Integer userId) {
+            @PathVariable Long userId) {
         logger.info("관리자 - 사용자 삭제 요청: userId={}", userId);
         return adminUserService.deleteUser(userId);
     }

--- a/src/main/java/com/example/ddingsroom/admin/dto/AdminUserDTO.java
+++ b/src/main/java/com/example/ddingsroom/admin/dto/AdminUserDTO.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 
 @Data
 public class AdminUserDTO {
-    private Integer id;
+    private Long id;
     private String email;
     private String username;
     private String age;

--- a/src/main/java/com/example/ddingsroom/admin/service/AdminReservationService.java
+++ b/src/main/java/com/example/ddingsroom/admin/service/AdminReservationService.java
@@ -65,7 +65,7 @@ public class AdminReservationService {
     /**
      * 특정 예약 상세 조회
      */
-    public ResponseEntity<?> getReservationById(Integer reservationId) {
+    public ResponseEntity<?> getReservationById(Long reservationId) {
         try {
             if (reservationId == null || reservationId <= 0) {
                 return ResponseEntity.badRequest()
@@ -94,7 +94,7 @@ public class AdminReservationService {
      * 예약 강제 취소 (관리자 권한)
      */
     @Transactional
-    public ResponseEntity<AdminResponseDTO> forceCancelReservation(Integer reservationId) {
+    public ResponseEntity<AdminResponseDTO> forceCancelReservation(Long reservationId) {
         try {
             if (reservationId == null || reservationId <= 0) {
                 return ResponseEntity.badRequest()
@@ -307,7 +307,7 @@ public class AdminReservationService {
     /**
      * 특정 사용자의 예약 목록 조회
      */
-    public ResponseEntity<?> getReservationsByUserId(Integer userId) {
+    public ResponseEntity<?> getReservationsByUserId(Long userId) {
         try {
             if (userId == null || userId <= 0) {
                 return ResponseEntity.badRequest()

--- a/src/main/java/com/example/ddingsroom/admin/service/AdminRoomService.java
+++ b/src/main/java/com/example/ddingsroom/admin/service/AdminRoomService.java
@@ -60,7 +60,7 @@ public class AdminRoomService {
     /**
      * 특정 스터디룸 상세 조회
      */
-    public ResponseEntity<?> getRoomById(Integer roomId) {
+    public ResponseEntity<?> getRoomById(Long roomId) {
         try {
             if (roomId == null || roomId <= 0) {
                 return ResponseEntity.badRequest()
@@ -130,7 +130,7 @@ public class AdminRoomService {
      * 스터디룸 정보 수정
      */
     @Transactional
-    public ResponseEntity<AdminResponseDTO> updateRoom(Integer roomId, AdminRoomRequestDTO roomRequestDTO) {
+    public ResponseEntity<AdminResponseDTO> updateRoom(Long roomId, AdminRoomRequestDTO roomRequestDTO) {
         try {
             if (roomId == null || roomId <= 0) {
                 return ResponseEntity.badRequest()
@@ -188,7 +188,7 @@ public class AdminRoomService {
      * 스터디룸 상태 변경
      */
     @Transactional
-    public ResponseEntity<AdminResponseDTO> updateRoomStatus(Integer roomId, String status) {
+    public ResponseEntity<AdminResponseDTO> updateRoomStatus(Long roomId, String status) {
         try {
             if (roomId == null || roomId <= 0) {
                 return ResponseEntity.badRequest()
@@ -225,7 +225,7 @@ public class AdminRoomService {
      * 스터디룸 삭제
      */
     @Transactional
-    public ResponseEntity<AdminResponseDTO> deleteRoom(Integer roomId) {
+    public ResponseEntity<AdminResponseDTO> deleteRoom(Long roomId) {
         try {
             if (roomId == null || roomId <= 0) {
                 return ResponseEntity.badRequest()
@@ -313,7 +313,7 @@ public class AdminRoomService {
     /**
      * 특정 스터디룸의 예약 현황 조회
      */
-    public ResponseEntity<?> getRoomReservations(Integer roomId) {
+    public ResponseEntity<?> getRoomReservations(Long roomId) {
         try {
             if (roomId == null || roomId <= 0) {
                 return ResponseEntity.badRequest()

--- a/src/main/java/com/example/ddingsroom/community_post/entity/CommunityPostEntity.java
+++ b/src/main/java/com/example/ddingsroom/community_post/entity/CommunityPostEntity.java
@@ -5,8 +5,12 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
+import com.example.ddingsroom.user.entity.UserEntity;
+import com.example.ddingsroom.community_post_comment.entity.CommunityPostCommentEntity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -20,8 +24,9 @@ public class CommunityPostEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
 
     @Column(name = "post-title")
     private String title;
@@ -35,8 +40,11 @@ public class CommunityPostEntity {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    @Column(name = "cetegory") // 테이블의 오타에 맞춤
+    @Column(name = "cetegory")
     private Integer category;
+
+    @OneToMany(mappedBy = "communityPost", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<CommunityPostCommentEntity> comments = new ArrayList<>();
 
     @PrePersist
     protected void onCreate() {
@@ -47,5 +55,12 @@ public class CommunityPostEntity {
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
+    }
+
+    public Long getUserId() {
+        return user != null ? user.getId() : null;
+    }
+
+    public void setUserId(Long userId) {
     }
 }

--- a/src/main/java/com/example/ddingsroom/community_post/repository/CommunityPostRepository.java
+++ b/src/main/java/com/example/ddingsroom/community_post/repository/CommunityPostRepository.java
@@ -5,24 +5,29 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Repository
 public interface CommunityPostRepository extends JpaRepository<CommunityPostEntity, Long> {
 
-    // ========== 기존 메서드들 (그대로 유지) ==========
-    List<CommunityPostEntity> findByUserId(Long userId);
+    // ========== 사용자 관련 조회 메서드 (user.id로 수정) ==========
+    @Query("SELECT p FROM CommunityPostEntity p WHERE p.user.id = :userId")
+    List<CommunityPostEntity> findByUserId(@Param("userId") Long userId);
+
     List<CommunityPostEntity> findByCategory(Integer category);
-    List<CommunityPostEntity> findByUserIdAndCategory(Long userId, Integer category);
+
+    @Query("SELECT p FROM CommunityPostEntity p WHERE p.user.id = :userId AND p.category = :category")
+    List<CommunityPostEntity> findByUserIdAndCategory(@Param("userId") Long userId, @Param("category") Integer category);
 
     // ========== 새로 추가할 메서드들 ==========
 
     // 사용자별 게시글 조회 (최신순)
-    @Query("SELECT p FROM CommunityPostEntity p WHERE p.userId = :userId ORDER BY p.createdAt DESC")
+    @Query("SELECT p FROM CommunityPostEntity p WHERE p.user.id = :userId ORDER BY p.createdAt DESC")
     List<CommunityPostEntity> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 
     // 사용자별 특정 카테고리 게시글 조회 (최신순)
-    @Query("SELECT p FROM CommunityPostEntity p WHERE p.userId = :userId AND p.category = :category ORDER BY p.createdAt DESC")
+    @Query("SELECT p FROM CommunityPostEntity p WHERE p.user.id = :userId AND p.category = :category ORDER BY p.createdAt DESC")
     List<CommunityPostEntity> findByUserIdAndCategoryOrderByCreatedAtDesc(@Param("userId") Long userId, @Param("category") Integer category);
 
     // 전체 게시글 조회 (최신순)
@@ -30,19 +35,23 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPostEnti
     List<CommunityPostEntity> findAllOrderByCreatedAtDesc();
 
     // 사용자별 게시글 개수 조회
-    Long countByUserId(Long userId);
+    @Query("SELECT COUNT(p) FROM CommunityPostEntity p WHERE p.user.id = :userId")
+    Long countByUserId(@Param("userId") Long userId);
 
     // 사용자별 특정 카테고리 게시글 개수 조회
-    Long countByUserIdAndCategory(Long userId, Integer category);
+    @Query("SELECT COUNT(p) FROM CommunityPostEntity p WHERE p.user.id = :userId AND p.category = :category")
+    Long countByUserIdAndCategory(@Param("userId") Long userId, @Param("category") Integer category);
 
     // 제목으로 검색
     @Query("SELECT p FROM CommunityPostEntity p WHERE p.title LIKE %:title% ORDER BY p.createdAt DESC")
     List<CommunityPostEntity> findByTitleContaining(@Param("title") String title);
 
     // 특정 사용자의 제목으로 검색
-    @Query("SELECT p FROM CommunityPostEntity p WHERE p.userId = :userId AND p.title LIKE %:title% ORDER BY p.createdAt DESC")
+    @Query("SELECT p FROM CommunityPostEntity p WHERE p.user.id = :userId AND p.title LIKE %:title% ORDER BY p.createdAt DESC")
     List<CommunityPostEntity> findByUserIdAndTitleContaining(@Param("userId") Long userId, @Param("title") String title);
 
     // 사용자의 모든 게시글 삭제
-    void deleteByUserId(Long userId);
+    @Transactional
+    @Query("DELETE FROM CommunityPostEntity p WHERE p.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/ddingsroom/community_post_comment/controller/CommunityPostCommentController.java
+++ b/src/main/java/com/example/ddingsroom/community_post_comment/controller/CommunityPostCommentController.java
@@ -1,8 +1,8 @@
-package com.example.ddingsroom.CommunityPostComment.controller;
+package com.example.ddingsroom.community_post_comment.controller;
 
-import com.example.ddingsroom.CommunityPostComment.dto.BaseResponseDTO;
-import com.example.ddingsroom.CommunityPostComment.dto.CommunityPostCommentRequestDTO;
-import com.example.ddingsroom.CommunityPostComment.service.CommunityPostCommentService;
+import com.example.ddingsroom.community_post_comment.dto.BaseResponseDTO;
+import com.example.ddingsroom.community_post_comment.dto.CommunityPostCommentRequestDTO;
+import com.example.ddingsroom.community_post_comment.service.CommunityPostCommentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/example/ddingsroom/community_post_comment/dto/BaseResponseDTO.java
+++ b/src/main/java/com/example/ddingsroom/community_post_comment/dto/BaseResponseDTO.java
@@ -1,4 +1,4 @@
-package com.example.ddingsroom.CommunityPostComment.dto;
+package com.example.ddingsroom.community_post_comment.dto;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/example/ddingsroom/community_post_comment/dto/CommunityPostCommentRequestDTO.java
+++ b/src/main/java/com/example/ddingsroom/community_post_comment/dto/CommunityPostCommentRequestDTO.java
@@ -1,4 +1,4 @@
-package com.example.ddingsroom.CommunityPostComment.dto;
+package com.example.ddingsroom.community_post_comment.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/src/main/java/com/example/ddingsroom/community_post_comment/dto/CommunityPostCommentResponseDTO.java
+++ b/src/main/java/com/example/ddingsroom/community_post_comment/dto/CommunityPostCommentResponseDTO.java
@@ -1,4 +1,4 @@
-package com.example.ddingsroom.CommunityPostComment.dto;
+package com.example.ddingsroom.community_post_comment.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/src/main/java/com/example/ddingsroom/community_post_comment/entity/CommunityPostCommentEntity.java
+++ b/src/main/java/com/example/ddingsroom/community_post_comment/entity/CommunityPostCommentEntity.java
@@ -1,10 +1,12 @@
-package com.example.ddingsroom.CommunityPostComment.entity;
+package com.example.ddingsroom.community_post_comment.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
+import com.example.ddingsroom.user.entity.UserEntity;
+import com.example.ddingsroom.community_post.entity.CommunityPostEntity;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -20,16 +22,17 @@ public class CommunityPostCommentEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "post_id", nullable = false)
-    private Long postId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private CommunityPostEntity communityPost;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
 
     @Column(name = "comment_content")
     private String commentContent;
 
-    // 대댓글을 위한 부모 댓글 ID (nullable)
     @Column(name = "parent_comment_id")
     private Long parentCommentId;
 
@@ -39,12 +42,10 @@ public class CommunityPostCommentEntity {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    // 부모 댓글 참조 (optional)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_comment_id", insertable = false, updatable = false)
     private CommunityPostCommentEntity parentComment;
 
-    // 자식 댓글들 (대댓글들)
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
     private List<CommunityPostCommentEntity> replies;
 
@@ -57,5 +58,19 @@ public class CommunityPostCommentEntity {
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
+    }
+
+    public Long getPostId() {
+        return communityPost != null ? communityPost.getId() : null;
+    }
+
+    public void setPostId(Long postId) {
+    }
+
+    public Long getUserId() {
+        return user != null ? user.getId() : null;
+    }
+
+    public void setUserId(Long userId) {
     }
 }

--- a/src/main/java/com/example/ddingsroom/community_post_comment/repository/CommunityPostCommentRepository.java
+++ b/src/main/java/com/example/ddingsroom/community_post_comment/repository/CommunityPostCommentRepository.java
@@ -1,44 +1,63 @@
-package com.example.ddingsroom.CommunityPostComment.repository;
+package com.example.ddingsroom.community_post_comment.repository;
 
-import com.example.ddingsroom.CommunityPostComment.entity.CommunityPostCommentEntity;
+import com.example.ddingsroom.community_post_comment.entity.CommunityPostCommentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Repository
 public interface CommunityPostCommentRepository extends JpaRepository<CommunityPostCommentEntity, Long> {
 
-    // 기존 메서드들
-    List<CommunityPostCommentEntity> findByPostId(Long postId);
-    List<CommunityPostCommentEntity> findByUserId(Long userId);
-    Long countByPostId(Long postId);
+    // 기존 메서드들 (JPA 관계로 수정)
+    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.communityPost.id = :postId")
+    List<CommunityPostCommentEntity> findByPostId(@Param("postId") Long postId);
+
+    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.user.id = :userId")
+    List<CommunityPostCommentEntity> findByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT COUNT(c) FROM CommunityPostCommentEntity c WHERE c.communityPost.id = :postId")
+    Long countByPostId(@Param("postId") Long postId);
 
     // 대댓글 관련 메서드들
     List<CommunityPostCommentEntity> findByParentCommentId(Long parentCommentId);
     Long countByParentCommentId(Long parentCommentId);
 
-    // 유저별 댓글 조회 메서드들
-    List<CommunityPostCommentEntity> findByUserIdAndParentCommentIdIsNull(Long userId);
-    List<CommunityPostCommentEntity> findByUserIdAndParentCommentIdIsNotNull(Long userId);
-    List<CommunityPostCommentEntity> findByUserIdAndPostId(Long userId, Long postId);
-    List<CommunityPostCommentEntity> findByUserIdAndPostIdAndParentCommentIdIsNull(Long userId, Long postId);
-    List<CommunityPostCommentEntity> findByUserIdAndPostIdAndParentCommentIdIsNotNull(Long userId, Long postId);
+    // 유저별 댓글 조회 메서드들 (JPA 관계로 수정)
+    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.user.id = :userId AND c.parentCommentId IS NULL")
+    List<CommunityPostCommentEntity> findByUserIdAndParentCommentIdIsNull(@Param("userId") Long userId);
+
+    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.user.id = :userId AND c.parentCommentId IS NOT NULL")
+    List<CommunityPostCommentEntity> findByUserIdAndParentCommentIdIsNotNull(@Param("userId") Long userId);
+
+    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.user.id = :userId AND c.communityPost.id = :postId")
+    List<CommunityPostCommentEntity> findByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
+
+    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.user.id = :userId AND c.communityPost.id = :postId AND c.parentCommentId IS NULL")
+    List<CommunityPostCommentEntity> findByUserIdAndPostIdAndParentCommentIdIsNull(@Param("userId") Long userId, @Param("postId") Long postId);
+
+    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.user.id = :userId AND c.communityPost.id = :postId AND c.parentCommentId IS NOT NULL")
+    List<CommunityPostCommentEntity> findByUserIdAndPostIdAndParentCommentIdIsNotNull(@Param("userId") Long userId, @Param("postId") Long postId);
 
     // 계층형 댓글 조회를 위한 @Query 메서드
-    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.postId = :postId " +
+    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.communityPost.id = :postId " +
             "ORDER BY CASE WHEN c.parentCommentId IS NULL THEN c.id ELSE c.parentCommentId END, " +
             "c.parentCommentId ASC NULLS FIRST, c.createdAt ASC")
     List<CommunityPostCommentEntity> findByPostIdOrderByHierarchy(@Param("postId") Long postId);
 
     // 사용자별 댓글 최신순 조회
-    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.userId = :userId ORDER BY c.createdAt DESC")
+    @Query("SELECT c FROM CommunityPostCommentEntity c WHERE c.user.id = :userId ORDER BY c.createdAt DESC")
     List<CommunityPostCommentEntity> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 
     // 특정 게시글의 모든 댓글 삭제
-    void deleteByPostId(Long postId);
+    @Transactional
+    @Query("DELETE FROM CommunityPostCommentEntity c WHERE c.communityPost.id = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
 
     // 특정 사용자의 모든 댓글 삭제
-    void deleteByUserId(Long userId);
+    @Transactional
+    @Query("DELETE FROM CommunityPostCommentEntity c WHERE c.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/ddingsroom/community_post_comment/service/CommunityPostCommentService.java
+++ b/src/main/java/com/example/ddingsroom/community_post_comment/service/CommunityPostCommentService.java
@@ -1,11 +1,13 @@
-package com.example.ddingsroom.CommunityPostComment.service;
+package com.example.ddingsroom.community_post_comment.service;
 
-import com.example.ddingsroom.CommunityPostComment.dto.BaseResponseDTO;
-import com.example.ddingsroom.CommunityPostComment.dto.CommunityPostCommentRequestDTO;
-import com.example.ddingsroom.CommunityPostComment.dto.CommunityPostCommentResponseDTO;
-import com.example.ddingsroom.CommunityPostComment.entity.CommunityPostCommentEntity;
-import com.example.ddingsroom.CommunityPostComment.repository.CommunityPostCommentRepository;
+import com.example.ddingsroom.community_post_comment.dto.BaseResponseDTO;
+import com.example.ddingsroom.community_post_comment.dto.CommunityPostCommentRequestDTO;
+import com.example.ddingsroom.community_post_comment.dto.CommunityPostCommentResponseDTO;
+import com.example.ddingsroom.community_post_comment.entity.CommunityPostCommentEntity;
+import com.example.ddingsroom.community_post_comment.repository.CommunityPostCommentRepository;
 import com.example.ddingsroom.community_post.repository.CommunityPostRepository;
+import com.example.ddingsroom.community_post.entity.CommunityPostEntity;
+import com.example.ddingsroom.user.entity.UserEntity;
 import com.example.ddingsroom.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -36,12 +38,14 @@ public class CommunityPostCommentService {
     public BaseResponseDTO createComment(CommunityPostCommentRequestDTO dto) {
         try {
             // 사용자 존재 확인
-            if (!userRepository.existsById(dto.getUserId().intValue())) {
+            UserEntity user = userRepository.findById(dto.getUserId()).orElse(null);
+            if (user == null) {
                 return BaseResponseDTO.error("존재하지 않는 사용자입니다.");
             }
 
             // 게시글 존재 확인
-            if (!postRepository.existsById(dto.getPostId())) {
+            CommunityPostEntity communityPost = postRepository.findById(dto.getPostId()).orElse(null);
+            if (communityPost == null) {
                 return BaseResponseDTO.error("존재하지 않는 게시글입니다.");
             }
 
@@ -58,8 +62,8 @@ public class CommunityPostCommentService {
             }
 
             CommunityPostCommentEntity entity = new CommunityPostCommentEntity();
-            entity.setPostId(dto.getPostId());
-            entity.setUserId(dto.getUserId());
+            entity.setCommunityPost(communityPost);
+            entity.setUser(user);
             entity.setCommentContent(dto.getCommentContent());
             entity.setParentCommentId(dto.getParentCommentId());
 

--- a/src/main/java/com/example/ddingsroom/config/SecurityUtils.java
+++ b/src/main/java/com/example/ddingsroom/config/SecurityUtils.java
@@ -35,7 +35,7 @@ public class SecurityUtils {
         if (userEntity == null) {
             throw new IllegalStateException("인증된 사용자(" + username + ")의 정보를 데이터베이스에서 찾을 수 없습니다.");
         }
-        return (long) userEntity.getId();
+        return userEntity.getId();
     }
 
     public boolean isAdmin(Authentication authentication) {

--- a/src/main/java/com/example/ddingsroom/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/ddingsroom/notification/controller/NotificationController.java
@@ -33,7 +33,7 @@ public class NotificationController {
     }
 
     @DeleteMapping("/delete/{id}")
-    public ResponseEntity<BaseResponseDTO> deleteNotification(@PathVariable Integer id) {
+    public ResponseEntity<BaseResponseDTO> deleteNotification(@PathVariable Long id) {
         BaseResponseDTO response = notificationService.deleteNotification(id);
         return ResponseEntity.ok(response);
     }
@@ -45,7 +45,7 @@ public class NotificationController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<BaseResponseDTO> getNotification(@PathVariable Integer id) {
+    public ResponseEntity<BaseResponseDTO> getNotification(@PathVariable Long id) {
         BaseResponseDTO response = notificationService.getNotification(id);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/ddingsroom/notification/dto/NotificationRequestDTO.java
+++ b/src/main/java/com/example/ddingsroom/notification/dto/NotificationRequestDTO.java
@@ -10,7 +10,7 @@ import lombok.AllArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class NotificationRequestDTO {
-    private Integer notificationId;
+    private Long notificationId;
     private String title;
     private String content;
 }

--- a/src/main/java/com/example/ddingsroom/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/example/ddingsroom/notification/dto/NotificationResponseDTO.java
@@ -12,8 +12,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class NotificationResponseDTO {
-    private Integer id;
-    private Integer userId;
+    private Long id;
+    private Long userId;
     private String title;
     private String content;
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/ddingsroom/notification/dto/NotificationUpdateRequestDTO.java
+++ b/src/main/java/com/example/ddingsroom/notification/dto/NotificationUpdateRequestDTO.java
@@ -10,7 +10,7 @@ import lombok.AllArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class NotificationUpdateRequestDTO {
-    private Integer notificationId;
+    private Long notificationId;
     private String title;
     private String content;
 }

--- a/src/main/java/com/example/ddingsroom/notification/dto/NotificationViewCountRequestDTO.java
+++ b/src/main/java/com/example/ddingsroom/notification/dto/NotificationViewCountRequestDTO.java
@@ -10,5 +10,5 @@ import lombok.AllArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class NotificationViewCountRequestDTO {
-    private Integer notificationId;
+    private Long notificationId;
 }

--- a/src/main/java/com/example/ddingsroom/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/example/ddingsroom/notification/entity/NotificationEntity.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
+import com.example.ddingsroom.user.entity.UserEntity;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -19,10 +20,11 @@ public class NotificationEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
-    @Column(name = "user_id", nullable = false)
-    private Integer userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
 
     @Column(name = "title")
     private String title;
@@ -52,5 +54,12 @@ public class NotificationEntity {
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
+
+    public Long getUserId() {
+        return user != null ? user.getId() : null;
+    }
+
+    public void setUserId(Long userId) {
     }
 }

--- a/src/main/java/com/example/ddingsroom/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/ddingsroom/notification/repository/NotificationRepository.java
@@ -5,12 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
-public interface NotificationRepository extends JpaRepository<NotificationEntity, Integer> {
+public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
 
     List<NotificationEntity> findAllByOrderByCreatedAtDesc();
 
@@ -22,5 +23,7 @@ public interface NotificationRepository extends JpaRepository<NotificationEntity
     List<NotificationEntity> findByContentContaining(String content);
 
     // 특정 사용자의 모든 공지사항 삭제
-    void deleteByUserId(Integer userId);
+    @Transactional
+    @Query("DELETE FROM NotificationEntity n WHERE n.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/ddingsroom/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/ddingsroom/reservation/controller/ReservationController.java
@@ -59,7 +59,7 @@ public class ReservationController {
     }
 
     @GetMapping("/user/{userId}")
-    public ResponseEntity<ReservationResponseDTO> getUserReservations(@PathVariable int userId) {
+    public ResponseEntity<ReservationResponseDTO> getUserReservations(@PathVariable Long userId) {
         logger.info("사용자 예약 조회 요청: userId={}", userId);
         
         ReservationResponseDTO response = reservationService.getUserReservations(userId);

--- a/src/main/java/com/example/ddingsroom/reservation/dto/ReservationCancelRequestDTO.java
+++ b/src/main/java/com/example/ddingsroom/reservation/dto/ReservationCancelRequestDTO.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class ReservationCancelRequestDTO {
-    private int userId;
-    private int reservationId;
+    private Long userId;
+    private Long reservationId;
 }

--- a/src/main/java/com/example/ddingsroom/reservation/dto/ReservationRequestDTO.java
+++ b/src/main/java/com/example/ddingsroom/reservation/dto/ReservationRequestDTO.java
@@ -6,8 +6,8 @@ import java.time.LocalDateTime;
 
 @Data
 public class ReservationRequestDTO {
-    private int userId;
-    private int roomId;
+    private Long userId;
+    private Long roomId;
     private LocalDateTime reservationStartTime;
     private LocalDateTime reservationEndTime;
 }

--- a/src/main/java/com/example/ddingsroom/reservation/dto/ReservationResponseDTO.java
+++ b/src/main/java/com/example/ddingsroom/reservation/dto/ReservationResponseDTO.java
@@ -14,9 +14,9 @@ public class ReservationResponseDTO {
 
     @Data
     public static class ReservationDTO {
-        private int id;
-        private int userId;
-        private int roomId;
+        private Long id;
+        private Long userId;
+        private Long roomId;
         private String roomName;
         private LocalDateTime startTime;
         private LocalDateTime endTime;

--- a/src/main/java/com/example/ddingsroom/reservation/entity/ReservationEntity.java
+++ b/src/main/java/com/example/ddingsroom/reservation/entity/ReservationEntity.java
@@ -26,7 +26,7 @@ import java.time.ZoneId;
 public class ReservationEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Long id;
     
     @ManyToOne
     @JoinColumn(name = "room_id")
@@ -52,5 +52,19 @@ public class ReservationEntity {
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
+
+    public Long getUserId() {
+        return user != null ? user.getId() : null;
+    }
+
+    public void setUserId(Long userId) {
+    }
+
+    public Long getRoomId() {
+        return room != null ? room.getId() : null;
+    }
+
+    public void setRoomId(Long roomId) {
     }
 }

--- a/src/main/java/com/example/ddingsroom/reservation/entity/RoomEntity.java
+++ b/src/main/java/com/example/ddingsroom/reservation/entity/RoomEntity.java
@@ -17,7 +17,7 @@ import lombok.Setter;
 public class RoomEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Long id;
     private String roomName;
     private String roomStatus;
 }

--- a/src/main/java/com/example/ddingsroom/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/example/ddingsroom/reservation/repository/ReservationRepository.java
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 @Repository
-public interface ReservationRepository extends JpaRepository<ReservationEntity, Integer> {
+public interface ReservationRepository extends JpaRepository<ReservationEntity, Long> {
     // 시간 범위가 겹치는 예약 검색
     @Query("SELECT r FROM ReservationEntity r WHERE r.room = :room AND r.status = 'RESERVED' " +
             "AND ((r.startTime < :endTime AND r.endTime > :startTime))")
@@ -29,7 +29,7 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
             "AND r.room.id = :roomId AND r.endTime = :startTime")
     List<ReservationEntity> findContinuousReservations(
             @Param("user") UserEntity user,
-            @Param("roomId") int roomId,
+            @Param("roomId") Long roomId,
             @Param("startTime") LocalDateTime startTime);
 
     // 동일 사용자의 동일 시간대 다른 룸 예약 검색

--- a/src/main/java/com/example/ddingsroom/reservation/repository/RoomRepository.java
+++ b/src/main/java/com/example/ddingsroom/reservation/repository/RoomRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RoomRepository extends JpaRepository<RoomEntity, Integer> {
+public interface RoomRepository extends JpaRepository<RoomEntity, Long> {
 }

--- a/src/main/java/com/example/ddingsroom/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/ddingsroom/reservation/service/ReservationService.java
@@ -246,7 +246,7 @@ public class ReservationService {
     }
     
     @Transactional(readOnly = true)
-    public ReservationResponseDTO getUserReservations(int userId) {
+    public ReservationResponseDTO getUserReservations(Long userId) {
         try {
             UserEntity user = userRepository.findById(userId)
                     .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));

--- a/src/main/java/com/example/ddingsroom/suggest_post/entity/SuggestPostEntity.java
+++ b/src/main/java/com/example/ddingsroom/suggest_post/entity/SuggestPostEntity.java
@@ -2,6 +2,7 @@ package com.example.ddingsroom.suggest_post.entity;
 
 import com.example.ddingsroom.suggest_post_comment.entity.SuggestPostCommentEntity;
 import com.example.ddingsroom.suggest_post_image.entity.SuggestPostImageEntity;
+import com.example.ddingsroom.user.entity.UserEntity;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
@@ -16,8 +17,9 @@ public class SuggestPostEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
 
     @Column(nullable = false, length = 255)
     private String suggestTitle;
@@ -50,8 +52,8 @@ public class SuggestPostEntity {
 
     }
 
-    public SuggestPostEntity(Long userId, String suggestTitle, String suggestContent, int category, int location) {
-        this.userId = userId;
+    public SuggestPostEntity(UserEntity user, String suggestTitle, String suggestContent, int category, int location) {
+        this.user = user;
         this.suggestTitle = suggestTitle;
         this.suggestContent = suggestContent;
         this.category = category;
@@ -77,11 +79,18 @@ public class SuggestPostEntity {
     }
 
     public Long getUserId(){
-        return this.userId;
+        return user != null ? user.getId() : null;
     }
 
     public void setUserId(Long userId){
-        this.userId = userId;
+    }
+
+    public UserEntity getUser(){
+        return this.user;
+    }
+
+    public void setUser(UserEntity user){
+        this.user = user;
     }
 
     public String getSuggestTitle(){
@@ -164,7 +173,7 @@ public class SuggestPostEntity {
     public String toString() {
         return "SuggestPost{"+
                 "id=" + id +
-                ", userId=" + userId +
+                ", userId=" + getUserId() +
                 ", suggestTitle=" + suggestTitle +
                 ", suggsetContent=" + suggestContent +
                 ", category=" + category +

--- a/src/main/java/com/example/ddingsroom/suggest_post/repository/SuggestPostRepository.java
+++ b/src/main/java/com/example/ddingsroom/suggest_post/repository/SuggestPostRepository.java
@@ -3,14 +3,20 @@ package com.example.ddingsroom.suggest_post.repository;
 import com.example.ddingsroom.suggest_post.entity.SuggestPostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface SuggestPostRepository extends JpaRepository<SuggestPostEntity, Long>, JpaSpecificationExecutor<SuggestPostEntity> {
     
     // 사용자의 모든 건의 게시글 삭제
-    void deleteByUserId(Long userId);
+    @Transactional
+    @Query("DELETE FROM SuggestPostEntity s WHERE s.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
     
     // 사용자의 모든 건의 게시글 조회
-    java.util.List<SuggestPostEntity> findByUserId(Long userId);
+    @Query("SELECT s FROM SuggestPostEntity s WHERE s.user.id = :userId")
+    java.util.List<SuggestPostEntity> findByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/ddingsroom/suggest_post_comment/entity/SuggestPostCommentEntity.java
+++ b/src/main/java/com/example/ddingsroom/suggest_post_comment/entity/SuggestPostCommentEntity.java
@@ -1,6 +1,7 @@
 package com.example.ddingsroom.suggest_post_comment.entity;
 
 import com.example.ddingsroom.suggest_post.entity.SuggestPostEntity;
+import com.example.ddingsroom.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,8 +26,9 @@ public class SuggestPostCommentEntity {
     @JoinColumn(name = "suggest_post_id", nullable = false, unique = true)
     private SuggestPostEntity suggestPost;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
 
     @Column(name = "answer_content", nullable = false, columnDefinition = "TEXT")
     private String answerContent;
@@ -37,9 +39,9 @@ public class SuggestPostCommentEntity {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public SuggestPostCommentEntity(SuggestPostEntity suggestPost, Long userId, String answerContent) {
+    public SuggestPostCommentEntity(SuggestPostEntity suggestPost, UserEntity user, String answerContent) {
         this.suggestPost = suggestPost;
-        this.userId = userId;
+        this.user = user;
         this.answerContent = answerContent;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
@@ -54,6 +56,13 @@ public class SuggestPostCommentEntity {
     @PreUpdate
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getUserId() {
+        return user != null ? user.getId() : null;
+    }
+
+    public void setUserId(Long userId) {
     }
 
 }

--- a/src/main/java/com/example/ddingsroom/suggest_post_comment/repository/SuggestPostCommentRepository.java
+++ b/src/main/java/com/example/ddingsroom/suggest_post_comment/repository/SuggestPostCommentRepository.java
@@ -2,7 +2,10 @@ package com.example.ddingsroom.suggest_post_comment.repository;
 
 import com.example.ddingsroom.suggest_post_comment.entity.SuggestPostCommentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -11,7 +14,9 @@ public interface SuggestPostCommentRepository extends JpaRepository<SuggestPostC
     List<SuggestPostCommentEntity> findAllBySuggestPost_Id(Long suggestPostId);
     
     // 사용자의 모든 건의 댓글 삭제
-    void deleteByUserId(Long userId);
+    @Transactional
+    @Query("DELETE FROM SuggestPostCommentEntity s WHERE s.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
     
     // 특정 게시글의 모든 댓글 삭제
     void deleteBySuggestPost_Id(Long suggestPostId);

--- a/src/main/java/com/example/ddingsroom/suggest_post_comment/service/SuggestPostCommentService.java
+++ b/src/main/java/com/example/ddingsroom/suggest_post_comment/service/SuggestPostCommentService.java
@@ -8,6 +8,8 @@ import com.example.ddingsroom.suggest_post_comment.dto.SuggestPostCommentUpdateR
 import com.example.ddingsroom.suggest_post_comment.dto.SuggestPostCommentDeleteRequestDTO;
 import com.example.ddingsroom.suggest_post_comment.entity.SuggestPostCommentEntity;
 import com.example.ddingsroom.suggest_post_comment.repository.SuggestPostCommentRepository;
+import com.example.ddingsroom.user.entity.UserEntity;
+import com.example.ddingsroom.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +23,7 @@ public class SuggestPostCommentService {
 
     private final SuggestPostCommentRepository suggestPostCommentRepository;
     private final SuggestPostRepository suggestPostRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public void createComment(SuggestPostCommentCreateRequestDTO request, Long authenticatedUserId) {
@@ -31,9 +34,12 @@ public class SuggestPostCommentService {
             throw new IllegalArgumentException("해당 건의 게시물(ID: " + request.getSuggestPostId() + ")에는 이미 댓글이 존재합니다.");
         }
 
+        UserEntity user = userRepository.findById(authenticatedUserId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID: " + authenticatedUserId));
+
         SuggestPostCommentEntity newComment = new SuggestPostCommentEntity(
                 suggestPost,
-                authenticatedUserId,
+                user,
                 request.getAnswerContent()
         );
 

--- a/src/main/java/com/example/ddingsroom/user/controller/JoinController.java
+++ b/src/main/java/com/example/ddingsroom/user/controller/JoinController.java
@@ -48,7 +48,7 @@ public class JoinController {
     }
 
     @GetMapping("/mypage/{userId}")
-    public ResponseEntity<?> getMyPage(@PathVariable Integer userId) {
+    public ResponseEntity<?> getMyPage(@PathVariable Long userId) {
         return joinService.getMyPage(userId);
     }
 
@@ -77,7 +77,7 @@ public class JoinController {
         // 인증된 사용자 정보 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        int userId = userDetails.getUserEntity().getId();
+        Long userId = userDetails.getUserEntity().getId();
         
         return joinService.withdrawUserById(userId);
     }

--- a/src/main/java/com/example/ddingsroom/user/controller/MainController.java
+++ b/src/main/java/com/example/ddingsroom/user/controller/MainController.java
@@ -21,7 +21,7 @@ public class MainController {
         // 사용자 상세 정보 추출
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
         String username = userDetails.getUsername();
-        int id = userDetails.getUserEntity().getId();
+        Long id = userDetails.getUserEntity().getId();
         String email = userDetails.getUserEntity().getEmail();
 
         // 역할 정보 추출

--- a/src/main/java/com/example/ddingsroom/user/controller/ReissueController.java
+++ b/src/main/java/com/example/ddingsroom/user/controller/ReissueController.java
@@ -75,7 +75,7 @@ public class ReissueController {
         // 토큰에서 모든 필요한 정보 추출
         String username = jwtUtil.getUsername(refresh);
         String role = jwtUtil.getRole(refresh);
-        int id = jwtUtil.getId(refresh);
+        Long id = jwtUtil.getId(refresh);
         String email = jwtUtil.getEmail(refresh);
 
         //make new JWT

--- a/src/main/java/com/example/ddingsroom/user/dto/ChangeUsernameDTO.java
+++ b/src/main/java/com/example/ddingsroom/user/dto/ChangeUsernameDTO.java
@@ -6,12 +6,12 @@ import lombok.Setter;
 @Setter
 @Getter
 public class ChangeUsernameDTO {
-    private Integer userId;
+    private Long userId;
     private String newUsername;
 
     public ChangeUsernameDTO() {}
 
-    public ChangeUsernameDTO(Integer userId, String newUsername) {
+    public ChangeUsernameDTO(Long userId, String newUsername) {
         this.userId = userId;
         this.newUsername = newUsername;
     }

--- a/src/main/java/com/example/ddingsroom/user/dto/MyPageDTO.java
+++ b/src/main/java/com/example/ddingsroom/user/dto/MyPageDTO.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 public class MyPageDTO {
-    private Integer id;
+    private Long id;
     private String email;
     private String username;
     private String age;

--- a/src/main/java/com/example/ddingsroom/user/entity/UserEntity.java
+++ b/src/main/java/com/example/ddingsroom/user/entity/UserEntity.java
@@ -1,16 +1,20 @@
 package com.example.ddingsroom.user.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
+import jakarta.persistence.*;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
+import com.example.ddingsroom.reservation.entity.ReservationEntity;
+import com.example.ddingsroom.community_post.entity.CommunityPostEntity;
+import com.example.ddingsroom.community_post_comment.entity.CommunityPostCommentEntity;
+import com.example.ddingsroom.suggest_post.entity.SuggestPostEntity;
+import com.example.ddingsroom.suggest_post_comment.entity.SuggestPostCommentEntity;
+import com.example.ddingsroom.notification.entity.NotificationEntity;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Data
@@ -19,7 +23,7 @@ import java.time.ZoneId;
 public class UserEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Long id;
     private String email;
     private String username;
     private String password;
@@ -28,6 +32,24 @@ public class UserEntity {
     private String role;
     private String state;
     private LocalDateTime registrationDate;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ReservationEntity> reservations = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<CommunityPostEntity> communityPosts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<CommunityPostCommentEntity> communityPostComments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<SuggestPostEntity> suggestPosts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<SuggestPostCommentEntity> suggestPostComments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<NotificationEntity> notifications = new ArrayList<>();
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/example/ddingsroom/user/jwt/JWTFilter.java
+++ b/src/main/java/com/example/ddingsroom/user/jwt/JWTFilter.java
@@ -58,7 +58,7 @@ public class JWTFilter extends OncePerRequestFilter {
         // 토큰에서 모든 사용자 정보 추출
         String username = jwtUtil.getUsername(accessToken);
         String role = jwtUtil.getRole(accessToken);
-        int id = jwtUtil.getId(accessToken);
+        Long id = jwtUtil.getId(accessToken);
         String email = jwtUtil.getEmail(accessToken);
 
         System.out.println("JWTFilter: Setting authentication for " + username + " with role " + role);

--- a/src/main/java/com/example/ddingsroom/user/jwt/JWTUtil.java
+++ b/src/main/java/com/example/ddingsroom/user/jwt/JWTUtil.java
@@ -28,8 +28,8 @@ public class JWTUtil {
     }
 
     // 새로 추가된 메소드: 토큰에서 ID 추출
-    public int getId(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id", Integer.class);
+    public Long getId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id", Long.class);
     }
 
     // 새로 추가된 메소드: 토큰에서 이메일 추출
@@ -42,7 +42,7 @@ public class JWTUtil {
     }
 
     // 메소드 시그니처 변경: ID와 이메일 파라미터 추가
-    public String createJwt(String category, String username, String role, int id, String email, Long expiredMs) {
+    public String createJwt(String category, String username, String role, Long id, String email, Long expiredMs) {
         return Jwts.builder()
                 .claim("category", category)
                 .claim("username", username)

--- a/src/main/java/com/example/ddingsroom/user/jwt/LoginFilter.java
+++ b/src/main/java/com/example/ddingsroom/user/jwt/LoginFilter.java
@@ -43,7 +43,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         // 사용자 정보 추출
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
         String username = userDetails.getUsername();
-        int id = userDetails.getUserEntity().getId();
+        Long id = userDetails.getUserEntity().getId();
         String email = userDetails.getUserEntity().getEmail();
 
         // 역할 정보 추출

--- a/src/main/java/com/example/ddingsroom/user/repository/UserRepository.java
+++ b/src/main/java/com/example/ddingsroom/user/repository/UserRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<UserEntity, Integer> {
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Boolean existsByUsername(String username);
     UserEntity findByUsername(String username);
     UserEntity findByEmail(String email);


### PR DESCRIPTION
# [Refactoring] Entity ID 타입 통일 및 JPA 관계 매핑 개선

## 개요
백엔드 데이터 일관성과 확장성을 위해 모든 Entity의 ID 타입을 Long으로 통일함. 
추가로 JPA 관계 매핑을 개선함.

## 주요 변경사항

### 1. Entity ID 타입 통일

모든 Entity의 ID 필드를 `int`/`Integer`에서 `Long` 타입으로 변경함

#### 변경된 Entity 목록
- **UserEntity**: `int id` → `Long id`
- **ReservationEntity**: `int id` → `Long id` 
- **RoomEntity**: `int id` → `Long id`
- **NotificationEntity**: `Integer id` → `Long id`

#### 관련 클래스 전면 업데이트
- **Repository 인터페이스**: `JpaRepository<Entity, Integer>` → `JpaRepository<Entity, Long>`
- **Service 클래스**: 모든 메서드 시그니처에서 `Integer`/`int` → `Long` 변경
- **Controller 클래스**: `@PathVariable Integer`/`int` → `@PathVariable Long` 변경
- **DTO 클래스**: 모든 ID 필드를 `Integer`/`int` → `Long`으로 변경
- **JWT 관련 클래스**: JWTUtil, JWTFilter, LoginFilter 등 `Long` 타입 지원

### 2. JPA 관계 매핑 개선

기존의 원시 타입 userId 필드를 적절한 JPA 관계 매핑으로 교체함.

#### 관계 매핑 구현
- **SuggestPostEntity**, **NotificationEntity**, **SuggestPostCommentEntity**에서 primitive `userId` 필드를 `@ManyToOne UserEntity user` 관계로 교체
- 모든 Entity에 양방향 관계 매핑 구현

#### Cascade 작업 설정
- `@OneToMany` 관계에 `cascade = CascadeType.ALL`, `orphanRemoval = true` 설정
- **사용자 삭제** → 관련된 모든 예약, 게시글, 댓글, 알림 자동 삭제
- **게시글 삭제** → 관련된 모든 댓글 자동 삭제
- **부모 댓글 삭제** → 모든 답글 자동 삭제

### 3. Service 클래스 간소화

JPA Cascade 기능 활용으로 수동 삭제 로직 간소화 진행
- **AdminUserService.deleteUser()**: 20+ 라인의 수동 삭제 로직 -> `userRepository.delete(user)` 한 줄로 간소화
- **CommunityPostService**: 수동 댓글 삭제 로직 제거
- **SuggestPostService**: 수동 삭제 대신 JPA cascade 활용으로 업데이트
- **NotificationService**: UserEntity 관계 작업에 맞춰 업데이트
