### PR TITLE
[Refactoring] 건의함 내역 조회 오류 해결

### DIFF
--- a/src/main/java/com/example/ddingsroom/admin/service/AdminUserService.java
+++ b/src/main/java/com/example/ddingsroom/admin/service/AdminUserService.java
@@ -171,9 +171,7 @@ public class AdminUserService {
             
             UserEntity user = userOptional.get();
             String username = user.getUsername();
-            
-            // JPA cascade를 통해 관련된 모든 데이터가 자동으로 삭제됩니다
-            // (예약, 커뮤니티 게시글, 댓글, 건의 게시글, 건의 댓글, 알림 등)
+
             userRepository.delete(user);
             
             return ResponseEntity.ok(AdminResponseDTO.success(

--- a/src/main/java/com/example/ddingsroom/suggest_post/service/SuggestPostSevice.java
+++ b/src/main/java/com/example/ddingsroom/suggest_post/service/SuggestPostSevice.java
@@ -110,7 +110,7 @@ public class SuggestPostSevice {
         Specification<SuggestPostEntity> spec = (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
             suggestId.ifPresent(id -> predicates.add(cb.equal(root.get("id"), id)));
-            userId.ifPresent(id -> predicates.add(cb.equal(root.get("userId"), id)));
+            userId.ifPresent(id -> predicates.add(cb.equal(root.get("user").get("id"), id)));
             categoryValueOpt.ifPresent(catVal -> predicates.add(cb.equal(root.get("category"), catVal)));
             locationValueOpt.ifPresent(locVal -> predicates.add(cb.equal(root.get("location"), locVal)));
             isAnswered.ifPresent(answered -> predicates.add(cb.equal(root.get("isAnswered"), answered)));
@@ -123,21 +123,18 @@ public class SuggestPostSevice {
                 .collect(Collectors.toList());
     }
 
-    // 사용자의 모든 건의 게시글 삭제 (JPA cascade로 댓글 자동 삭제)
     @Transactional
     public void deleteAllUserSuggestPosts(Long userId) {
         try {
-            // JPA cascade를 통해 관련된 모든 댓글이 자동으로 삭제됩니다
             suggestPostRepository.deleteByUserId(userId);
         } catch (Exception e) {
             throw new RuntimeException("사용자 건의 게시글 삭제 중 오류가 발생했습니다: " + e.getMessage());
         }
     }
 
-    // 사용자의 모든 건의 댓글 삭제 (JPA cascade로 자동 삭제됨)
+    // 사용자의 모든 건의 댓글 삭제
     @Transactional  
     public void deleteAllUserSuggestComments(Long userId) {
-        // 이 메서드는 더 이상 필요하지 않습니다.
-        // UserEntity 삭제 시 JPA cascade를 통해 자동으로 삭제됩니다.
+        // UserEntity 삭제 시 JPA cascade를 통해 자동으로 삭제될거라 필요없어짐
     }
 }

--- a/src/main/java/com/example/ddingsroom/user/service/JoinService.java
+++ b/src/main/java/com/example/ddingsroom/user/service/JoinService.java
@@ -306,12 +306,9 @@ public class JoinService {
                         .body(new ResponseDTO("해당 사용자를 찾을 수 없습니다."));
             }
 
-            // JPA cascade로 자동 삭제되지 않는 데이터만 수동으로 삭제
-            // (refresh token, verification code는 User와 직접적인 JPA 관계가 없음)
             refreshRepository.deleteByUsername(email);
             verificationCodeRepository.findByEmail(email).ifPresent(verificationCodeRepository::delete);
 
-            // UserEntity 삭제 - JPA cascade를 통해 관련된 모든 데이터가 자동으로 삭제됩니다
             userRepository.delete(user);
 
             return ResponseEntity.ok(new ResponseDTO("회원탈퇴가 성공적으로 완료되었습니다."));


### PR DESCRIPTION
## [Refactoring] 건의함 내역 조회 오류 해결

### 건의 내역 조회 불가 문제
  - 원인: JPA Specification에서 root.get("userId") 사용했던게 문제
  - 해결: root.get("user").get("id")로 수정하여 엔티티 관계 매핑 방식에 맞게 변경

### 테스트 결과
=> 정상작동함